### PR TITLE
feat: MVP reusable workflow launcher for exe.dev runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - exe

--- a/.github/workflows/test-exe-runner.yml
+++ b/.github/workflows/test-exe-runner.yml
@@ -1,0 +1,62 @@
+name: Test exe.dev Runner
+
+on:
+  workflow_dispatch:
+
+jobs:
+  provision:
+    name: Provision exe.dev runner
+    runs-on: ubuntu-latest
+    outputs:
+      vm_name: ${{ steps.setup.outputs.vm_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./setup-exe-runner
+        id: setup
+        with:
+          exe-ssh-key: ${{ secrets.EXE_SSH_KEY }}
+          github-token: ${{ secrets.GH_RUNNER_TOKEN }}
+
+  test:
+    name: Run tests on exe.dev
+    needs: provision
+    runs-on: [self-hosted, exe]
+    steps:
+      - name: System info
+        run: |
+          echo "=== Running on exe.dev ==="
+          echo "Hostname: $(hostname)"
+          echo "OS: $(uname -a)"
+          echo "CPU: $(nproc) cores"
+          echo "Memory: $(free -h | grep Mem | awk '{print $2}')"
+          echo "Disk: $(df -h / | tail -1 | awk '{print $4}') free"
+          echo "User: $(whoami)"
+
+      - uses: actions/checkout@v4
+
+      - name: Verify checkout
+        run: |
+          echo "=== Repository checkout ==="
+          ls -la
+          echo "Branch: $(git branch --show-current || git rev-parse --short HEAD)"
+          echo "Commit: $(git rev-parse --short HEAD)"
+
+      - name: Docker smoke test
+        run: |
+          echo "=== Docker test ==="
+          docker run --rm alpine:latest echo "Docker works on exe.dev!"
+          docker version --format '{{.Server.Version}}'
+
+  teardown:
+    name: Teardown exe.dev runner
+    runs-on: ubuntu-latest
+    needs: [provision, test]
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./teardown-exe-runner
+        with:
+          exe-ssh-key: ${{ secrets.EXE_SSH_KEY }}
+          vm-name: ${{ needs.provision.outputs.vm_name }}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+actionlint = "latest"

--- a/setup-exe-runner/action.yml
+++ b/setup-exe-runner/action.yml
@@ -1,0 +1,160 @@
+name: 'Setup exe.dev Runner'
+description: 'Provisions an exe.dev VM as an ephemeral GitHub Actions self-hosted runner'
+
+inputs:
+  exe-ssh-key:
+    description: 'SSH private key for exe.dev (ed25519)'
+    required: true
+  github-token:
+    description: 'GitHub token with administration:write scope for JIT runner config'
+    required: true
+  labels:
+    description: 'Comma-separated runner labels (self-hosted is always included automatically)'
+    required: false
+    default: 'exe'
+
+outputs:
+  vm_name:
+    description: 'Name of the provisioned exe.dev VM'
+    value: ${{ steps.create-vm.outputs.vm_name }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup SSH for exe.dev
+      shell: bash
+      env:
+        EXE_SSH_KEY: ${{ inputs.exe-ssh-key }}
+      run: |
+        set -euo pipefail
+        mkdir -p ~/.ssh
+        chmod 700 ~/.ssh
+        printf '%s\n' "$EXE_SSH_KEY" > ~/.ssh/exe_dev_key
+        chmod 600 ~/.ssh/exe_dev_key
+        {
+          echo "Host exe.dev *.exe.xyz"
+          echo "  IdentitiesOnly yes"
+          echo "  IdentityFile ~/.ssh/exe_dev_key"
+          echo "  StrictHostKeyChecking accept-new"
+          echo "  UserKnownHostsFile ~/.ssh/known_hosts"
+        } >> ~/.ssh/config
+        chmod 600 ~/.ssh/config
+
+    - name: Create exe.dev VM
+      id: create-vm
+      shell: bash
+      run: |
+        set -euo pipefail
+        VM_NAME="exeunt-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        echo "Creating VM: $VM_NAME"
+        ssh exe.dev new --name="$VM_NAME" --json --no-email
+        echo "vm_name=$VM_NAME" >> "$GITHUB_OUTPUT"
+
+        # Wait for VM to be SSH-accessible
+        echo "Waiting for VM SSH access..."
+        for i in $(seq 1 15); do
+          if ssh -o ConnectTimeout=5 "${VM_NAME}.exe.xyz" true 2>/dev/null; then
+            echo "VM is SSH-accessible"
+            break
+          fi
+          if [ "$i" = "15" ]; then
+            echo "::error::VM not SSH-accessible after 15 attempts"
+            exit 1
+          fi
+          sleep 2
+        done
+
+    - name: Generate JIT runner config
+      id: jit-config
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        VM_NAME: ${{ steps.create-vm.outputs.vm_name }}
+        RUNNER_LABELS: ${{ inputs.labels }}
+      run: |
+        set -euo pipefail
+
+        # Build labels JSON array
+        LABELS_JSON=$(echo "$RUNNER_LABELS" | tr ',' '\n' | jq -R . | jq -s .)
+
+        JIT_RESPONSE=$(curl -sf -X POST \
+          -H "Authorization: Bearer $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runners/generate-jitconfig" \
+          -d "{\"name\":\"${VM_NAME}\",\"runner_group_id\":1,\"labels\":${LABELS_JSON},\"work_folder\":\"_work\"}")
+
+        JIT_CONFIG=$(echo "$JIT_RESPONSE" | jq -r '.encoded_jit_config')
+
+        if [ -z "$JIT_CONFIG" ] || [ "$JIT_CONFIG" = "null" ]; then
+          echo "::error::Failed to generate JIT config"
+          echo "$JIT_RESPONSE" >&2
+          exit 1
+        fi
+
+        # Mask the JIT config so it doesn't appear in logs
+        echo "::add-mask::$JIT_CONFIG"
+        echo "encoded_jit_config=$JIT_CONFIG" >> "$GITHUB_OUTPUT"
+
+    - name: Get runner download URL
+      id: runner-url
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        RUNNER_URL=$(curl -sf \
+          -H "Authorization: Bearer $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runners/downloads" \
+          | jq -r '.[] | select(.os == "linux" and .architecture == "x64") | .download_url')
+
+        if [ -z "$RUNNER_URL" ]; then
+          echo "::error::Failed to get runner download URL"
+          exit 1
+        fi
+
+        echo "Runner URL: $RUNNER_URL"
+        echo "runner_url=$RUNNER_URL" >> "$GITHUB_OUTPUT"
+
+    - name: Install and start runner on VM
+      shell: bash
+      env:
+        VM_NAME: ${{ steps.create-vm.outputs.vm_name }}
+        RUNNER_URL: ${{ steps.runner-url.outputs.runner_url }}
+        JIT_CONFIG: ${{ steps.jit-config.outputs.encoded_jit_config }}
+      run: |
+        set -euo pipefail
+        echo "Installing runner on ${VM_NAME}.exe.xyz"
+
+        ssh "${VM_NAME}.exe.xyz" bash -s -- "$RUNNER_URL" "$JIT_CONFIG" << 'REMOTE'
+        set -euo pipefail
+        RUNNER_URL="$1"
+        JIT_CONFIG="$2"
+
+        mkdir -p ~/actions-runner && cd ~/actions-runner
+        echo "Downloading runner..."
+        curl -sL "$RUNNER_URL" -o runner.tar.gz
+        tar xzf runner.tar.gz
+        rm runner.tar.gz
+
+        echo "Starting runner with JIT config..."
+        nohup ./run.sh --jitconfig "$JIT_CONFIG" > runner.log 2>&1 &
+        disown
+
+        # Wait for runner to connect to GitHub
+        for i in $(seq 1 30); do
+          if grep -q "Listening for Jobs" runner.log 2>/dev/null; then
+            echo "Runner connected and listening for jobs"
+            exit 0
+          fi
+          sleep 1
+        done
+
+        echo "ERROR: Runner did not connect within 30 seconds" >&2
+        cat runner.log >&2
+        exit 1
+        REMOTE
+
+        echo "Runner is ready on $VM_NAME"

--- a/teardown-exe-runner/action.yml
+++ b/teardown-exe-runner/action.yml
@@ -1,0 +1,56 @@
+name: 'Teardown exe.dev Runner'
+description: 'Destroys an exe.dev VM provisioned by setup-exe-runner'
+
+inputs:
+  exe-ssh-key:
+    description: 'SSH private key for exe.dev (ed25519)'
+    required: true
+  vm-name:
+    description: 'Name of the exe.dev VM to destroy'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup SSH for exe.dev
+      shell: bash
+      env:
+        EXE_SSH_KEY: ${{ inputs.exe-ssh-key }}
+      run: |
+        set -euo pipefail
+        mkdir -p ~/.ssh
+        chmod 700 ~/.ssh
+        printf '%s\n' "$EXE_SSH_KEY" > ~/.ssh/exe_dev_key
+        chmod 600 ~/.ssh/exe_dev_key
+        {
+          echo "Host exe.dev *.exe.xyz"
+          echo "  IdentitiesOnly yes"
+          echo "  IdentityFile ~/.ssh/exe_dev_key"
+          echo "  StrictHostKeyChecking accept-new"
+          echo "  UserKnownHostsFile ~/.ssh/known_hosts"
+        } >> ~/.ssh/config
+        chmod 600 ~/.ssh/config
+
+    - name: Destroy exe.dev VM
+      shell: bash
+      env:
+        VM_NAME: ${{ inputs.vm-name }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "$VM_NAME" ]; then
+          echo "::warning::No VM name provided, skipping teardown"
+          exit 0
+        fi
+
+        echo "Destroying VM: $VM_NAME"
+        ssh exe.dev rm "$VM_NAME" || echo "::warning::Failed to destroy VM $VM_NAME (may already be gone)"
+
+        # Verify removal
+        echo "Verifying VM removal..."
+        REMAINING=$(ssh exe.dev ls --json | jq -r ".vms[] | select(.vm_name == \"$VM_NAME\") | .vm_name")
+        if [ -n "$REMAINING" ]; then
+          echo "::warning::VM $VM_NAME still exists after rm"
+        else
+          echo "VM $VM_NAME destroyed successfully"
+        fi


### PR DESCRIPTION
## Summary

- Adds `setup-exe-runner` composite action: provisions an exe.dev VM, downloads the GitHub Actions runner binary, configures it with JIT config, and starts it listening for jobs
- Adds `teardown-exe-runner` composite action: destroys the VM with verification
- Adds `test-exe-runner.yml` workflow: end-to-end test (provision → run on exe.dev → teardown) triggered via `workflow_dispatch`
- Adds `mise.toml` with actionlint and `.github/actionlint.yaml` for custom runner labels

## Test plan

- [ ] Add `EXE_SSH_KEY` (ed25519 private key for exe.dev) as a repo secret
- [ ] Add `GH_RUNNER_TOKEN` (PAT with `administration:write` scope) as a repo secret
- [ ] Trigger test workflow via `gh workflow run test-exe-runner.yml`
- [ ] Verify provision job creates VM and runner connects
- [ ] Verify test job runs on exe.dev with checkout and Docker working
- [ ] Verify teardown job destroys the VM
- [ ] Verify teardown runs even if test job fails

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)