### PR TITLE
fix: SSH to VMs as exedev user, never root

### DIFF
--- a/setup-exe-runner/action.yml
+++ b/setup-exe-runner/action.yml
@@ -36,7 +36,14 @@ runs:
         printf '%s\n' "$EXE_SSH_KEY" > ~/.ssh/exe_dev_key
         chmod 600 ~/.ssh/exe_dev_key
         {
-          echo "Host exe.dev *.exe.xyz"
+          echo "Host exe.dev"
+          echo "  IdentitiesOnly yes"
+          echo "  IdentityFile ~/.ssh/exe_dev_key"
+          echo "  StrictHostKeyChecking accept-new"
+          echo "  UserKnownHostsFile ~/.ssh/known_hosts"
+          echo ""
+          echo "Host *.exe.xyz"
+          echo "  User exedev"
           echo "  IdentitiesOnly yes"
           echo "  IdentityFile ~/.ssh/exe_dev_key"
           echo "  StrictHostKeyChecking accept-new"
@@ -121,7 +128,7 @@ runs:
         set -euo pipefail
         JIT_CONFIG="$1"
 
-        cd /home/exedev/actions-runner
+        cd ~/actions-runner
 
         echo "Starting runner with JIT config..."
         nohup ./run.sh --jitconfig "$JIT_CONFIG" > runner.log 2>&1 &

--- a/teardown-exe-runner/action.yml
+++ b/teardown-exe-runner/action.yml
@@ -23,7 +23,14 @@ runs:
         printf '%s\n' "$EXE_SSH_KEY" > ~/.ssh/exe_dev_key
         chmod 600 ~/.ssh/exe_dev_key
         {
-          echo "Host exe.dev *.exe.xyz"
+          echo "Host exe.dev"
+          echo "  IdentitiesOnly yes"
+          echo "  IdentityFile ~/.ssh/exe_dev_key"
+          echo "  StrictHostKeyChecking accept-new"
+          echo "  UserKnownHostsFile ~/.ssh/known_hosts"
+          echo ""
+          echo "Host *.exe.xyz"
+          echo "  User exedev"
           echo "  IdentitiesOnly yes"
           echo "  IdentityFile ~/.ssh/exe_dev_key"
           echo "  StrictHostKeyChecking accept-new"


### PR DESCRIPTION
Split SSH config: exe.dev has no User, *.exe.xyz always connects as exedev.