### PR TITLE
fix: explicitly SSH as exedev@ for VM connections

### DIFF
--- a/setup-exe-runner/action.yml
+++ b/setup-exe-runner/action.yml
@@ -36,14 +36,7 @@ runs:
         printf '%s\n' "$EXE_SSH_KEY" > ~/.ssh/exe_dev_key
         chmod 600 ~/.ssh/exe_dev_key
         {
-          echo "Host exe.dev"
-          echo "  IdentitiesOnly yes"
-          echo "  IdentityFile ~/.ssh/exe_dev_key"
-          echo "  StrictHostKeyChecking accept-new"
-          echo "  UserKnownHostsFile ~/.ssh/known_hosts"
-          echo ""
-          echo "Host *.exe.xyz"
-          echo "  User exedev"
+          echo "Host exe.dev *.exe.xyz"
           echo "  IdentitiesOnly yes"
           echo "  IdentityFile ~/.ssh/exe_dev_key"
           echo "  StrictHostKeyChecking accept-new"
@@ -65,7 +58,7 @@ runs:
         # Wait for VM to be SSH-accessible
         echo "Waiting for VM SSH access..."
         for i in $(seq 1 15); do
-          if ssh -o ConnectTimeout=5 "${VM_NAME}.exe.xyz" true 2>/dev/null; then
+          if ssh -o ConnectTimeout=5 "exedev@${VM_NAME}.exe.xyz" true 2>/dev/null; then
             echo "VM is SSH-accessible"
             break
           fi
@@ -124,7 +117,7 @@ runs:
         set -euo pipefail
         echo "Starting runner on ${VM_NAME}.exe.xyz"
 
-        ssh "${VM_NAME}.exe.xyz" bash -s -- "$JIT_CONFIG" << 'REMOTE'
+        ssh "exedev@${VM_NAME}.exe.xyz" bash -s -- "$JIT_CONFIG" << 'REMOTE'
         set -euo pipefail
         JIT_CONFIG="$1"
 

--- a/teardown-exe-runner/action.yml
+++ b/teardown-exe-runner/action.yml
@@ -23,14 +23,7 @@ runs:
         printf '%s\n' "$EXE_SSH_KEY" > ~/.ssh/exe_dev_key
         chmod 600 ~/.ssh/exe_dev_key
         {
-          echo "Host exe.dev"
-          echo "  IdentitiesOnly yes"
-          echo "  IdentityFile ~/.ssh/exe_dev_key"
-          echo "  StrictHostKeyChecking accept-new"
-          echo "  UserKnownHostsFile ~/.ssh/known_hosts"
-          echo ""
-          echo "Host *.exe.xyz"
-          echo "  User exedev"
+          echo "Host exe.dev *.exe.xyz"
           echo "  IdentitiesOnly yes"
           echo "  IdentityFile ~/.ssh/exe_dev_key"
           echo "  StrictHostKeyChecking accept-new"


### PR DESCRIPTION
exe.dev proxy ignores SSH User directive. Use exedev@ prefix instead.